### PR TITLE
Multi-row Table Parsing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   matrix:
     - PYTHON: "C:\\Python27"
+      MINICONDA: "C:\Miniconda"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
 
@@ -9,8 +10,11 @@ environment:
 #      PYTHON_ARCH: "64"
 
 install:
-  - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
-  - pip.exe install -r requirements-dev.txt
+  - set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
+  - conda update -q conda --yes
+  - conda create -q -n appveyor-tests python=%PYTHON_VERSION% --yes
+  - activate appveyor-tests
+  - conda install --file requirements-dev.txt --yes
   - python setup.py install
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
     - PYTHON: "C:\\Python27"
-      MINICONDA: "C:\Miniconda"
+      MINICONDA: "C:\\Miniconda"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ install:
   - conda create -q -n appveyor-tests python=%PYTHON_VERSION% --yes
   - activate appveyor-tests
   - conda install --file requirements-dev.txt --yes
+  - conda install -c conda-forge pyproj
   - python setup.py install
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   matrix:
     - PYTHON: "C:\\Python27"
       MINICONDA: "C:\\Miniconda"
-      PYTHON_VERSION: "2.7.x"
+      PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
 
 #    - PYTHON: "C:\\Python27-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - conda create -q -n appveyor-tests python=%PYTHON_VERSION% --yes
   - activate appveyor-tests
   - conda install --file requirements-dev.txt --yes
-  - conda install -c conda-forge pyproj
+  - conda install -c conda-forge pyproj --yes
   - python setup.py install
 
 build: off

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+Cython
 coverage
 flake8
 pylint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 unicodecsv
-pywoudc
+pywoudc==0.1.9

--- a/tests/data/test-non-ascii.TO1
+++ b/tests/data/test-non-ascii.TO1
@@ -19,7 +19,7 @@ Date,Agency,Version,ScientificAuthority
 
 #PLATFORM
 Type,ID,Name,Country,GAW_ID
-STN,436,La Réunion,REU
+STN,436,La Réunion,FRA
 
 #INSTRUMENT
 Name,Model,Number

--- a/woudc_extcsv/__init__.py
+++ b/woudc_extcsv/__init__.py
@@ -351,19 +351,19 @@ spelled incorrectly.')
         agency_params = {'property_name': 'acronym', 'property_value': f_agency} # noqa
         platform_id_params = {'property_name' : 'platform_id', 'property_value' : f_ID} # noqa
         platform_name_params = {'property_name' : 'platform_name', 'property_value' : f_name} # noqa
-        if client.get_data('stations', filters=agency_params) is None:
+        if client.get_data('stations', **agency_params) is None:
             agency_params['property_name'] = 'contributor_name'
-            data = client.get_data('stations', filters=agency_params)
+            data = client.get_data('stations', **agency_params)
             if data is None:
                 acronym_set = Set()
                 LOGGER.debug('Resolving Agency through platform ID.')
-                data = client.get_data('stations', filters=platform_id_params)
+                data = client.get_data('stations', **platform_id_params)
                 if data is not None:
                     for row in data['features']:
                         properties = row['properties']
                         acronym_set.add(properties['acronym'])
                 LOGGER.debug('Resolving Agency through platform name.')
-                data = client.get_data('stations', filters=platform_name_params)
+                data = client.get_data('stations', **platform_name_params)
                 if data is not None:
                     for row in data['features']:
                         properties = row['properties']
@@ -389,7 +389,7 @@ Agency acronym of %s.' % acronym) # noqa
 
         LOGGER.info('Successfully validated Agency.')
         LOGGER.debug('Resolving platform information.')
-        data = client.get_data('stations', filters=platform_id_params)
+        data = client.get_data('stations', **platform_id_params)
         flag = False
         a_set = Set()
         if data is not None:
@@ -429,7 +429,7 @@ to %s' % (f_gaw_id, properties['gaw_id']))
                     LOGGER.info('Successfully validated platform.')
                     flag = True
         if not flag:
-            data = client.get_data('stations', filters=platform_name_params)
+            data = client.get_data('stations', **platform_name_params)
             if data is not None:
                 for row in data['features']:
                     properties = row['properties']
@@ -486,7 +486,7 @@ please notify WOUDC.')
         inst_model_upper = inst_model.upper()
         inst_name_params = {'property_name': 'instrument_name', 'property_value': inst_name} # noqa
         inst_model_params = {'property_name': 'instrument_model', 'property_value': inst_model} # noqa
-        data = client.get_data('instruments', filters=inst_name_params)
+        data = client.get_data('instruments', **inst_name_params)
         if data is None:
             LOGGER.info('Failed to located Instrument name.')
             error_dict['errors'].append('Instrument Name is not in database. \
@@ -505,13 +505,13 @@ this file will be rejected and then manually processed into the database.')
 class/data_category/data_level for this agency.\nThe \
 file will be rejected and then manually processed into the database.')
 
-        data = client.get_data('instruments', filters=inst_model_params)
+        data = client.get_data('instruments', **inst_model_params)
         if data is None:
             inst_model_params['property_value'] = inst_model_upper
-            data = client.get_data('instruments', filters=inst_model_params)
+            data = client.get_data('instruments', **inst_model_params)
             if data is None:
                 inst_model_params['property_value'] = inst_model.title()
-                data = client.get_data('instruments', filters=inst_model_params)
+                data = client.get_data('instruments', **inst_model_params)
                 if data is None:
                     LOGGER.info('Failed to located Instrument model.')
                     error_dict['errors'].append('Instrument Model \

--- a/woudc_extcsv/__init__.py
+++ b/woudc_extcsv/__init__.py
@@ -195,8 +195,9 @@ class Reader(object):
                         self.errors.append(_violation_lookup(10))
                     elif len(columns[0]) > 0 and columns[0][0] == '*':
                         self.errors.append(_violation_lookup(8))
-                    if parse_table:
+                    if parse_tables:
                         table = {col: [] for col in columns}
+                    w.writerow(columns)
                 except StopIteration:
                     msg = 'Extended CSV table %s has no fields' % header
                     LOGGER.info(msg)

--- a/woudc_extcsv/__init__.py
+++ b/woudc_extcsv/__init__.py
@@ -191,7 +191,7 @@ class Reader(object):
                     if columns is None:
                         columns = row
                         if parse_tables:
-                            table = { col: [] for col in row }
+                            table = {col: [] for col in row}
                     if all([row != '', row is not None, row != []]):
                         if '*' not in row[0]:
                             w.writerow(row)

--- a/woudc_extcsv/__init__.py
+++ b/woudc_extcsv/__init__.py
@@ -195,8 +195,12 @@ class Reader(object):
                     if all([row != '', row is not None, row != []]):
                         if '*' not in row[0]:
                             w.writerow(row)
-                            # Extend the list representing each table column
+                            # Extend the table dictionary if this row is a
+                            # data row.
                             if row != columns and parse_tables:
+                                # Fill in omitted columns with null strings.
+                                unlisted_size = len(columns) - len(row)
+                                row.extend([''] * unlisted_size)
                                 for col, datapoint in zip(columns, row):
                                     table[col].append(datapoint)
                         else:
@@ -261,8 +265,9 @@ class Reader(object):
 
         if len(self.errors) != 0:
             self.errors = list(set(self.errors))
+            error_text = '; '.join(map(str, self.errors))
             msg = 'Unable to parse extended CSV file\n'
-            raise WOUDCExtCSVReaderError(msg, self.errors)
+            raise WOUDCExtCSVReaderError(msg + error_text, self.errors)
 
     def __eq__(self, other):
         """

--- a/woudc_extcsv/__init__.py
+++ b/woudc_extcsv/__init__.py
@@ -351,19 +351,19 @@ spelled incorrectly.')
         agency_params = {'property_name': 'acronym', 'property_value': f_agency} # noqa
         platform_id_params = {'property_name' : 'platform_id', 'property_value' : f_ID} # noqa
         platform_name_params = {'property_name' : 'platform_name', 'property_value' : f_name} # noqa
-        if client.get_data('stations', **agency_params) is None:
+        if client.get_data('stations', filters=agency_params) is None:
             agency_params['property_name'] = 'contributor_name'
-            data = client.get_data('stations', **agency_params)
+            data = client.get_data('stations', filters=agency_params)
             if data is None:
                 acronym_set = Set()
                 LOGGER.debug('Resolving Agency through platform ID.')
-                data = client.get_data('stations', **platform_id_params)
+                data = client.get_data('stations', filters=platform_id_params)
                 if data is not None:
                     for row in data['features']:
                         properties = row['properties']
                         acronym_set.add(properties['acronym'])
                 LOGGER.debug('Resolving Agency through platform name.')
-                data = client.get_data('stations', **platform_name_params)
+                data = client.get_data('stations', filters=platform_name_params)
                 if data is not None:
                     for row in data['features']:
                         properties = row['properties']
@@ -389,7 +389,7 @@ Agency acronym of %s.' % acronym) # noqa
 
         LOGGER.info('Successfully validated Agency.')
         LOGGER.debug('Resolving platform information.')
-        data = client.get_data('stations', **platform_id_params)
+        data = client.get_data('stations', filters=platform_id_params)
         flag = False
         a_set = Set()
         if data is not None:
@@ -429,7 +429,7 @@ to %s' % (f_gaw_id, properties['gaw_id']))
                     LOGGER.info('Successfully validated platform.')
                     flag = True
         if not flag:
-            data = client.get_data('stations', **platform_name_params)
+            data = client.get_data('stations', filters=platform_name_params)
             if data is not None:
                 for row in data['features']:
                     properties = row['properties']
@@ -486,7 +486,7 @@ please notify WOUDC.')
         inst_model_upper = inst_model.upper()
         inst_name_params = {'property_name': 'instrument_name', 'property_value': inst_name} # noqa
         inst_model_params = {'property_name': 'instrument_model', 'property_value': inst_model} # noqa
-        data = client.get_data('instruments', **inst_name_params)
+        data = client.get_data('instruments', filters=inst_name_params)
         if data is None:
             LOGGER.info('Failed to located Instrument name.')
             error_dict['errors'].append('Instrument Name is not in database. \
@@ -505,13 +505,13 @@ this file will be rejected and then manually processed into the database.')
 class/data_category/data_level for this agency.\nThe \
 file will be rejected and then manually processed into the database.')
 
-        data = client.get_data('instruments', **inst_model_params)
+        data = client.get_data('instruments', filters=inst_model_params)
         if data is None:
             inst_model_params['property_value'] = inst_model_upper
-            data = client.get_data('instruments', **inst_model_params)
+            data = client.get_data('instruments', filters=inst_model_params)
             if data is None:
                 inst_model_params['property_value'] = inst_model.title()
-                data = client.get_data('instruments', **inst_model_params)
+                data = client.get_data('instruments', filters=inst_model_params)
                 if data is None:
                     LOGGER.info('Failed to located Instrument model.')
                     error_dict['errors'].append('Instrument Model \


### PR DESCRIPTION
Rather than leaving large tables such as GLOBAL, PROFILE, and DAILY as raw strings, added an option enabling parsing these tables into a dictionary which holds a mapping for each table column. This makes the output for large tables similar to that for small, single-row tables.

Table parsing is enabled by setting the `parse_tables` kwarg to `True` in any of the following: `load`, `loads`, `Reader.__init__`. Default behaviour is to produce raw strings only.