### PR TITLE
Fix table-name regex

### DIFF
--- a/woudc_extcsv/__init__.py
+++ b/woudc_extcsv/__init__.py
@@ -293,7 +293,7 @@ class Reader(object):
 
         # Split on # characters, at the start of a line, and any following
         # sequence of capital letters and underscores.
-        blocks = re.split(r'(?<![ \w\d])#([A-Z0-9_]+)', raw)
+        blocks = re.split(r'(?<![ \w\d])#([A-Z][A-Z0-9_]*)', raw)
         if len(blocks) < 2:
             LOGGER.error('No tables found.')
 


### PR DESCRIPTION
Prevents entirely numeric strings after a '#' character from being recognized as table names: this is how they often appear in comments, referring to an instrument number.