### PR TITLE
Apply Python 3 to Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ Python package providing read/write support of the
 
 ### Requirements
 
-woudc-extcsv requires Python 2.7, [pywoudc](https://github.com/woudc/pywoudc), and unicodecsv.
+woudc-extcsv requires Python 3 and [pywoudc](https://github.com/woudc/pywoudc).
 
 ### Dependencies
 
 See `requirements.txt`
-- unicodecsv
 - [pywoudc](https://github.com/woudc/pywoudc)
 
 ### Installing the Package
@@ -36,8 +35,8 @@ easy_install woudc-extcsv
 ```python
 from woudc_extcsv import Reader
 # read from file
-with open('file.csv', 'rb') as ff:
-    ecsv = Reader(ff.read(), encoding='utf-8')
+with open('file.csv', 'r') as ff:
+    ecsv = Reader(ff.read())
 # read from string
 ecsv = Reader(my_ecsv_string)
 ```

--- a/examples/general-reader-example.py
+++ b/examples/general-reader-example.py
@@ -46,7 +46,7 @@
 # TotalOzone reader example 1
 
 import csv
-from StringIO import StringIO
+from io import StringIO
 from woudc_extcsv import load
 
 
@@ -156,17 +156,17 @@ print('DAILY table and content:')
 print(DAILY_raw)
 DAILY = StringIO(DAILY_raw)
 DAILY_rows = csv.reader(DAILY)
-DAILY_header = DAILY_rows.next()
+DAILY_header = next(DAILY_rows)
 print('DAILY fields:')
 print(DAILY_header)
 print('')
 # get first row of values
-DAILY_row_1 = DAILY_rows.next()
+DAILY_row_1 = next(DAILY_rows)
 print('DAILY row 1 values:')
 print(DAILY_row_1)
 print('')
 # get second row of values
-DAILY_row_2 = DAILY_rows.next()
+DAILY_row_2 = next(DAILY_rows)
 print('DAILY row 2 values:')
 print(DAILY_row_2)
 print('')
@@ -178,7 +178,7 @@ print('')
 # get all ColumnO3
 DAILY = StringIO(DAILY_raw)
 DAILY_rows = csv.reader(DAILY)
-DAILY_header = DAILY_rows.next()
+DAILY_header = next(DAILY_rows)
 print('All DAILY ColumnO3 values:')
 for row in DAILY_rows:
     DAILY_ColumnO3 = row[DAILY_header.index('ColumnO3')]

--- a/woudc_extcsv/__init__.py
+++ b/woudc_extcsv/__init__.py
@@ -881,7 +881,7 @@ class Writer(object):
         if all([data is not None, all_occurences]):  # remove all
             LOGGER.info('removing all occurences')
             val = filter(lambda a: a != data, self.extcsv_ds[table_n][field])
-            self.extcsv_ds[table_n][field] = val
+            self.extcsv_ds[table_n][field] = list(val)
             msg = 'data %s field %s table %s index %s removed' % \
                   (data, field, table, index)
             LOGGER.info(msg)
@@ -1230,7 +1230,7 @@ def dump(extcsv_obj, filename):
     :returns: void, writes file to disk
     """
     LOGGER.info('Dumping Extended CSV object to file: %s' % filename)
-    with open(filename, 'wb') as ff:
+    with open(filename, 'w') as ff:
         ff.write(_dump(extcsv_obj))
 
 


### PR DESCRIPTION
 * Updated miscellaneous files to Python 3 standards, including tests cases in `examples` directory and the `README`.

 * Fixed miscellaneous Python 3-related errors that were caught by `examples` tests