### PR TITLE
Add Python 3.7 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
   - "3.5"
+  - "3.7"
 
 before_install:
   - sudo apt-get update -qq

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,10 @@ environment:
       MINICONDA: "C:\\Miniconda3"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "32"
+    - PYTHON: "C:\\Python37"
+      MINICONDA: "C:\\Miniconda3"
+      PYTHON_VERSION: "3.7"
+      PYTHON_ARCH: "32"
 
 install:
   - set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%

--- a/woudc_extcsv/__init__.py
+++ b/woudc_extcsv/__init__.py
@@ -154,11 +154,15 @@ class Reader(object):
                     self.errors.append(_violation_lookup(140, header))
                     continue
                 try:
-                    anything_more = next(c)[0].strip()
-                    if all([anything_more is not None, anything_more != '',
-                            anything_more != os.linesep,
-                            '*' not in anything_more]):
-                        self.errors.append(_violation_lookup(140, header))
+                    anything_more = next(c)
+                    if len(anything_more) > 0:
+                        row_start = anything_more[0].strip()
+                        if all([row_start != '', row_start != os.linesep,
+                                '*' not in row_start]):
+                            self.errors.append(_violation_lookup(140, header))
+                except StopIteration:
+                    msg = 'End of table {} detected'.format(header)
+                    LOGGER.debug(msg)
                 except Exception as err:
                     LOGGER.warning(err)
                 if len(values) > len(fields):


### PR DESCRIPTION
Python 3.7 support.

Fixes an issue where empty lines were logged to stderr every time a metadata table was parsed.