### PR TITLE
Change "read line" log comment from Info to Debug

### DIFF
--- a/woudc_extcsv/__init__.py
+++ b/woudc_extcsv/__init__.py
@@ -248,7 +248,7 @@ class ExtendedCSV(object):
                 row = next(csv.reader(StringIO(comma_separated)))
                 if not self._add_to_report(104, line_num, separator=separator):
                     success = False
-            LOGGER.info(f'Read line {line_num}: {row}')
+            LOGGER.debug(f'Read line {line_num}: {row}')
 
             if len(row) > 0 and row[0].startswith('*'):  # comment
                 LOGGER.debug(f'Found comment: {row}')


### PR DESCRIPTION
 The info logger status will cause the log file to take up more space than necessary when processing heavy data (such as uv-index). 